### PR TITLE
fix: add packageManager to root package.json for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ceegee",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "dev": "pnpm --filter engine-ui dev",
     "build": "pnpm --filter engine-ui build",


### PR DESCRIPTION
pnpm/action-setup reads from the repo root, not working-directory.